### PR TITLE
Fix FireGauge app login link

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,8 +12,9 @@ const Navbar = () => {
   
   const isHome = location.pathname === '/';
 
-  // Get the main app URL from environment
-  const appUrl = import.meta.env.VITE_API_URL || 'https://app.firegauge.com';
+  // Get the FireGauge App login URL from environment
+  const appUrl =
+    import.meta.env.VITE_API_URL || 'https://app.firegauge.app/login';
 
   useEffect(() => {
     const handleScroll = () => {


### PR DESCRIPTION
## Summary
- update the default link to the FireGauge app login

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*
- `npm test` *(fails: tests could not run due to mocked modules and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6862cc2c8fa08324b94cb9c5670dd6a4